### PR TITLE
Feature cn 47 add missing manifest

### DIFF
--- a/src/components/AddManifest.js
+++ b/src/components/AddManifest.js
@@ -1,0 +1,67 @@
+import {useState, useEffect, useContext} from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import AddCircleIcon from '@material-ui/icons/AddCircle'
+import { Tooltip } from '@material-ui/core'
+import { IconButton } from '@material-ui/core'
+
+import { AuthContext } from '@context/AuthContext'
+import * as dcsApis from '@utils/dcsApis'
+// import { BIBLE_AND_OBS } from '@common/BooksOfTheBible'
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    color: theme.palette.primary.main,
+    backgroundColor: props => (props.active ? '#ffffff' : 'transparent'),
+    '&:hover': {
+      color: props => (props.active ? '#ffffff' : theme.palette.primary.main),
+      backgroundColor: props => (props.active ? '#07b811' : '#ffffff'),
+    },
+    border: '1px solid #0089C7',
+  },
+}))
+
+
+function AddManifest({ active, server, owner, repo, manifest, onRefresh }) {
+  const {
+    state: {
+      authentication,
+    },
+  } = useContext(AuthContext)
+
+  const [submitAddManifest, setSubmitAddManifest] = useState(false)
+   
+  useEffect(() => {
+    if ( !submitAddManifest ) return;
+
+    async function doSubmitAddManifest() {
+      const tokenid = authentication.token.sha1;
+      const resourceId = dcsApis.getResourceIdFromRepo(repo)
+      const manifestCreateRes = await dcsApis.manifestCreate({
+        server: server, 
+        username: owner, 
+        repository: repo, 
+        tokenid
+      })
+      if ( manifestCreateRes.status === 201 ) {
+        console.log("Manifest Created! Parameters:",`Server:${server}, Owner:${owner}, Repo:${repo}`)
+      } else {
+        console.log('Manifest Create Error:', manifestCreateRes)
+        console.log("Manifest Failed! Parameters:",`Server:${server}, Owner:${owner}, Repo:${repo}`)
+      }
+        setSubmitAddManifest(false)
+        onRefresh(resourceId)    
+    }
+    doSubmitAddManifest()
+  }, [submitAddManifest, server, owner, repo, manifest, onRefresh])
+    
+  const classes = useStyles({ active })
+  return (
+      <Tooltip title={`Add manifest to repository`}>
+        <IconButton className={classes.iconButton} onClick={() => setSubmitAddManifest(true)} aria-label="Add Manifest">
+          <AddCircleIcon />
+        </IconButton>
+      </Tooltip>
+  )
+}
+
+export default AddManifest

--- a/src/components/iconHelper.js
+++ b/src/components/iconHelper.js
@@ -45,7 +45,7 @@ export function applyIcon(server,owner,bookId,
     )
   }
 
-  if ( repoErr === NO_MANIFEST_FOUND ) {
+  if ( repoErr === NO_MANIFEST_FOUND || repoErr === NO_FILES_IN_REPO ) {
     return (
       <AddManifest active={true} server={server} owner={owner} 
       repo={repo} refresh={refresh} onRefresh={setRefresh} />

--- a/src/components/iconHelper.js
+++ b/src/components/iconHelper.js
@@ -1,4 +1,4 @@
-import {WORKING,REPO_NOT_FOUND,BOOK_NOT_IN_MANIFEST,OK}
+import {WORKING,REPO_NOT_FOUND,BOOK_NOT_IN_MANIFEST,OK, NO_MANIFEST_FOUND}
 from '@common/constants'
 
 import { Tooltip } from '@material-ui/core'
@@ -9,6 +9,7 @@ import BlockIcon from '@material-ui/icons/Block'
 
 import CreateRepoButton from './CreateRepoButton'
 import AddBookToManifest from './AddBookToManifest'
+import AddManifest from './AddManifest'
 
 import ViewListButton from './ViewListButton'
 
@@ -41,6 +42,13 @@ export function applyIcon(server,owner,bookId,
     return (
       <CreateRepoButton active={true} server={server} owner={owner} 
       repo={repo} refresh={refresh} bookId={bookId} onRefresh={setRefresh} />
+    )
+  }
+
+  if ( repoErr === NO_MANIFEST_FOUND ) {
+    return (
+      <AddManifest active={true} server={server} owner={owner} 
+      repo={repo} refresh={refresh} onRefresh={setRefresh} />
     )
   }
 


### PR DESCRIPTION
# Describe what your pull request addresses

- [ ] If a repo is missing a manifest
- [ ] if a repo has no files at all
- [ ] then this will offer to create the manifest appropriate for the repo
- [ ] Note - the manifest will be created without any projects. Thus it will have an invalid sticker until a book is added (this is for scripture resources; for non-scripture resources, it will show "file not found"

## Test Instructions

- [ ] See "test 8" in `TESTING.md`
