### PR TITLE
Fixes #176 - Decode and Encode the manifest.yaml file to/from utf8 string, not ASCII

### DIFF
--- a/src/utils/dcsApis.js
+++ b/src/utils/dcsApis.js
@@ -494,7 +494,7 @@ async function updateManifestInBranch({
 
   const body = await releaseBranchRes.json()
   const newYAML = YAML.dump(manifest)
-  const newContent = btoa(newYAML)
+  const newContent = Buffer.from(newYAML, 'utf8').toString('base64')
   const updateUri = server + '/' + Path.join(apiPath,'repos',organization,`${languageId}_${resourceId}`,'contents','manifest.yaml')
   const date = new Date(Date.now())
   const dateString = date.toISOString()

--- a/src/utils/dcsApis.js
+++ b/src/utils/dcsApis.js
@@ -430,7 +430,7 @@ export async function updateManifest({
 
   const body = await res.json()
   const sha = body.sha
-  const content = atob(body.content)
+  const content = Buffer.from(body.content, "base64").toString("utf8")
   const manifest = YAML.load( content )
 
   if ( nextVersion.startsWith('v') ) {


### PR DESCRIPTION
Fixes issue #176. Uses Buffer.from().toString() to decode the encoded base64 string of the manifest file to utf8. atob() converts to ASCII. Languages like Farsi get corrupted. Try publishing on QA qa.door43.org/fa_gl/fa_tn to test.

# Describe what your pull request addresses

- [ ] Fixes reading the manifest.yaml file from the content API which requires decoding base64 string to UTF8. 

## Test Instructions

- [ ] We noticed this happening when using GA to publish org fa_gl's fa_tn. It choked on the language name in the manifest since it was written in Farsi.
- [ ] Add yourself to the fa_gl org https://qa.door43.org/fa_gl
- [ ] Log into https://deploy-preview-175--gateway-admin.netlify.app?server=QA
- [ ] Go to the fa_gl org, Farsi language. Go to do a release
- [ ] Release 3JN or TIT, release fa_tn

See sandbox with code showing atob (BAD) and Buffer (good). You may need to hit the reload button the far right for the log so you can see both: https://codesandbox.io/p/sandbox/blazing-dawn-fu3xee

Here is what it looked like when it was broken:

![image](https://github.com/unfoldingWord/gateway-admin/assets/2839925/2af7e388-a3de-41bd-9201-fbe68236933f)

Should see this now:

![image](https://github.com/unfoldingWord/gateway-admin/assets/2839925/9c4c068a-7760-4de1-8ca5-e9e8e97560da)
